### PR TITLE
Mise à jour pour correspondre à la documentation

### DIFF
--- a/config/integrations/automation.yaml
+++ b/config/integrations/automation.yaml
@@ -4,5 +4,5 @@
 #
 # https://www.home-assistant.io/docs/automation/
 #
-automation: !include ../automations.yaml
-automation split: !include_dir_merge_list ../automations
+automation ui: !include ../automations.yaml
+automation manual: !include_dir_merge_list ../automations/


### PR DESCRIPTION
La [documentation](https://www.home-assistant.io/docs/configuration/splitting_configuration/#example-combine-include_dir_merge_list-with-automationsyaml) indique de faire ainsi pour séparer les automatismes fait par l'UI ou dans les fichiers .yaml